### PR TITLE
removed cassandra contact point definition from router-admin pom

### DIFF
--- a/ols-router-admin/pom.xml
+++ b/ols-router-admin/pom.xml
@@ -10,7 +10,6 @@
   <name>OLS Router Admin</name>
   
   <properties>
-  	<cassandraContactPoint>hummingbird.animals</cassandraContactPoint>
     <springframework.version>5.1.3.RELEASE</springframework.version>
     <springframework.security.version>5.1.2.RELEASE</springframework.security.version>
   </properties>


### PR DESCRIPTION
removed cassandra contact point definition from router-admin pom so that parent pom is used